### PR TITLE
Update Islam module search to v1.1

### DIFF
--- a/truth-dashboard/assets/search.js
+++ b/truth-dashboard/assets/search.js
@@ -1,43 +1,81 @@
 import { renderCard } from './ui.js';
 
-async function boot(){
-  const idxRes = await fetch('./data/search_index.json',{cache:'no-cache'});
-  const data = await idxRes.json();
+async function boot() {
+  // Load full-text index (Qur’an + Hadith)
+  const res = await fetch('./data/search_index.json', { cache: 'no-cache' });
+  const data = await res.json();
   const items = data.items;
 
+  // MiniSearch is provided via assets/vendor/minisearch.min.js (global)
   const mini = new MiniSearch({
-    fields:['title','content','tags','source'],
-    storeFields:['id','title','url','source','published','excerpt'],
-    searchOptions:{ boost:{title:6,tags:3,source:1,content:1}, prefix:true, fuzzy:0.1 },
-    tokenize: t => (t||'').toLowerCase().match(/[\p{L}\p{N}_]+/gu)||[]
+    fields: ['title', 'content', 'tags', 'source'],
+    storeFields: ['id', 'title', 'url', 'source', 'published', 'excerpt'],
+    searchOptions: { boost: { title: 6, tags: 3, source: 1, content: 1 }, prefix: true, fuzzy: 0.1 },
+    tokenize: t => (t || '').toLowerCase().match(/[\p{L}\p{N}_]+/gu) || []
   });
   mini.addAll(items);
 
-  const q = document.querySelector('#q');
-  const src = document.querySelector('#src');
-  const surah = document.querySelector('#surah');
-  const list = document.querySelector('#list');
-  const count = document.querySelector('#count');
+  // UI elements
+  const q     = document.getElementById('q');
+  const src   = document.getElementById('src');
+  const surah = document.getElementById('surah');
+  const list  = document.getElementById('list');
+  const count = document.getElementById('count');
 
-  // populate source filter
-  [...new Set(items.map(i=>i.source))].sort().forEach(s=>{ const o=document.createElement('option'); o.value=s; o.textContent=s; src.appendChild(o); });
-  // populate surah filter from tags like "Surah N"
-  [...new Set(items.flatMap(i=>i.tags||[]).filter(t=>/^Surah /.test(t)))].sort((a,b)=>{
-    const na = parseInt(a.replace(/\D+/g,''),10); const nb = parseInt(b.replace(/\D+/g,''),10); return na-nb; }).forEach(t=>{ const o=document.createElement('option'); o.value=t; o.textContent=t; surah.appendChild(o); });
+  // Populate source filter
+  [...new Set(items.map(i => i.source))].sort().forEach(s => {
+    const o = document.createElement('option'); o.value = s; o.textContent = s; src.appendChild(o);
+  });
 
-  function apply(){
+  // Populate surah filter from tags like "Surah N"
+  [...new Set(items.flatMap(i => i.tags || []).filter(t => /^Surah /.test(t)))]
+    .sort((a, b) => parseInt(a.replace(/\D+/g, ''), 10) - parseInt(b.replace(/\D+/g, ''), 10))
+    .forEach(t => { const o = document.createElement('option'); o.value = t; o.textContent = t; surah.appendChild(o); });
+
+  function apply() {
     const query = q.value.trim();
-    const s = src.value; const su = surah.value;
-    let results = query? mini.search(query).map(r=>r) : items;
-    if(s) results = results.filter(r => (r.source===s) || (r._src && r._src.source===s));
-    if(su) results = results.filter(r => (r.tags||[]).includes(su));
+    const s = src.value;
+    const su = surah.value;
+
+    let results = query ? mini.search(query) : items;
+    // MiniSearch results are objects; raw items are plain. Normalize.
+    if (query) results = results.map(r => ('id' in r ? items.find(i => i.id === r.id) : r));
+
+    if (s)  results = results.filter(r => r.source === s);
+    if (su) results = results.filter(r => (r.tags || []).includes(su));
+
     count.textContent = results.length;
     list.innerHTML = results.map(renderCard(query)).join('');
   }
 
+  // Events
   q.addEventListener('input', apply);
   src.addEventListener('change', apply);
   surah.addEventListener('change', apply);
+
+  // Preset queries (buttons under the search bar)
+  const presets = document.getElementById('presets');
+  if (presets) {
+    presets.addEventListener('click', (e) => {
+      const btn = e.target.closest('button[data-q]');
+      if (!btn) return;
+      q.value = btn.dataset.q || '';
+      apply();
+    });
+  }
+
+  // Copy citation (event delegation)
+  document.addEventListener('click', (e) => {
+    const b = e.target.closest('button.copy');
+    if (!b) return;
+    const cite = b.dataset.cite || '';
+    navigator.clipboard.writeText(cite).then(() => {
+      const prev = b.textContent;
+      b.textContent = 'Copied';
+      setTimeout(() => { b.textContent = prev || 'Copy citation'; }, 1200);
+    });
+  });
+
   apply();
 }
 boot();

--- a/truth-dashboard/assets/styles.css
+++ b/truth-dashboard/assets/styles.css
@@ -13,3 +13,7 @@ input,select{background:#0e141d;border:1px solid #202838;color:var(--text);paddi
 mark{background:#234e77;color:inherit;padding:0 .15em;border-radius:4px}
 .badge{background:#0e141d;border:1px solid #202838;padding:6px 10px;border-radius:999px;color:var(--muted)}
 .footer{color:var(--muted);border-top:1px solid var(--border);padding:24px 20px;margin-top:40px}
+/* New buttons / presets */
+button{cursor:pointer;background:#0e141d;border:1px solid #202838;color:var(--text);padding:8px 10px;border-radius:10px}
+button.copy{float:right}
+.presets{display:flex;gap:8px;flex-wrap:wrap}

--- a/truth-dashboard/assets/ui.js
+++ b/truth-dashboard/assets/ui.js
@@ -1,17 +1,27 @@
-export const escapeRegExp = s => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+export const escapeRegExp = s => s.replace(/[.*+?^${}()|[\]\]/g, "\$&");
+
 export const highlight = (text, q) => {
-  if(!q || !text) return text||'';
-  const terms = [...new Set((q.toLowerCase().match(/[\p{L}\p{N}_"]+/gu)||[]).filter(t=>t!== '"' && t.length>1))];
-  if(!terms.length) return text;
-  const pattern = new RegExp("("+terms.map(escapeRegExp).join("|")+")","giu");
-  return text.replace(pattern,'<mark>$1</mark>');
+  if (!q || !text) return text || '';
+  const terms = [...new Set((q.toLowerCase().match(/[\p{L}\p{N}_"]+/gu) || [])
+    .filter(t => t !== '"' && t.length > 1))];
+  if (!terms.length) return text;
+  const pattern = new RegExp("(" + terms.map(escapeRegExp).join("|") + ")", "giu");
+  return text.replace(pattern, '<mark>$1</mark>');
 };
+
 export const renderCard = (q) => (it) => `
   <article class="card">
     <header>
-      <h3><a href="${it.url}" target="_blank" rel="noopener">${highlight(it.title,q)}</a></h3>
-      <div class="meta"><span>${it.source}</span><span>•</span><time>${it.published? new Date(it.published).toLocaleString(): 'n/a'}</time></div>
+      <h3><a href="${it.url}" target="_blank" rel="noopener">${highlight(it.title, q)}</a></h3>
+      <div class="meta">
+        <span>${it.source}</span><span>•</span>
+        <time>${it.published ? new Date(it.published).toLocaleString() : 'n/a'}</time>
+      </div>
     </header>
-    <p>${highlight(it.excerpt||'',q)}</p>
-    <footer><a href="${it.url}" target="_blank" rel="noopener">Read at source →</a></footer>
-  </article>`;
+    <p>${highlight(it.excerpt || '', q)}</p>
+    <footer>
+      <a href="${it.url}" target="_blank" rel="noopener">Read at source →</a>
+      <button class="copy" data-cite="${(it.title || '').replace(/"/g, "'")} — ${it.source} — ${it.url}">Copy citation</button>
+    </footer>
+  </article>
+`;

--- a/truth-dashboard/data/sources.yml
+++ b/truth-dashboard/data/sources.yml
@@ -1,8 +1,8 @@
 quran_api:
   base: "https://api.quran.com/api/v4"
-  chapters: [1,2,3,4,5]     # initial subset; can expand to 1..114 later
-  translations: [131]        # Sahih International; can adjust later
+  chapters: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114]
+  translations: [131]  # Sahih International; adjust later if desired
 sunnah_api:
   base: "https://api.sunnah.com/v1"
-  collections: ["bukhari","muslim"]
+  collections: ["bukhari", "muslim", "abudawud", "tirmidhi", "nasai", "ibnmajah"]
   per_collection_limit: 200

--- a/truth-dashboard/islam.html
+++ b/truth-dashboard/islam.html
@@ -10,12 +10,17 @@
   <header class="site">
     <div class="container">
       <h1>Islam Module</h1>
-      <p class="muted">Search Qur'an (select translations) and authentic hadith (Bukhari/Muslim). All results link to the original pages.</p>
+      <p class="muted">Search Qur'an (selected translations) and authentic hadith (Kutub al-Sittah). All results link to the original pages.</p>
       <p><span class="badge"><span id="count">0</span> results</span></p>
       <div class="controls">
         <input id="q" type="search" placeholder="Search verses & hadith…" aria-label="Search">
         <select id="src" aria-label="Filter by source"><option value="">All sources</option></select>
         <select id="surah" aria-label="Filter by surah"><option value="">All surahs</option></select>
+        <div id="presets" class="presets">
+          <button data-q='"no compulsion"'>No compulsion</button>
+          <button data-q="People of the Book">People of the Book</button>
+          <button data-q="intention deeds">Intentions</button>
+        </div>
       </div>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- Expand the Qur'an API configuration to cover all 114 surahs and add the six major hadith collections to the Sunnah API settings.
- Refresh the Islam module UI markup and search module to support preset queries, filters, and copyable citations using the MiniSearch index.
- Tweak styling to cover the new preset and copy citation buttons.

## Testing
- Not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68e677aed2148323b3e07a1719175447